### PR TITLE
Fix Blueprint function calling for PHP 7

### DIFF
--- a/src/Flask.class.php
+++ b/src/Flask.class.php
@@ -35,7 +35,7 @@ class Flask extends HTTPHandler {
                     if ($b_route['path'] == $uri) {
                         $obj->init();
 
-                        echo $obj->$b_route['func']();
+                        echo call_user_func([$obj, $b_route['func']]);
 
                         return;
                     }


### PR DESCRIPTION
The previous code for calling Blueprint functions worked with PHP 5.6, but not with PHP 7.
The new code with `call_user_func` in place works for both. I think it's worth having it.